### PR TITLE
Set TLS version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
     $destination = "c:\vault\$vault_zip"
     if (!(Test-Path $destination)) {
         Write-Output "Downloading $vault_url"
+        [Net.ServicePointManager]::SecurityProtocol = 'Tls12'
         Start-FileDownload $vault_url -FileName $destination
     }
     7z x -y c:\vault\$vault_zip -oc:\vault\


### PR DESCRIPTION
Hashicorp or whatever they use for providing binaries has reduced the available versions of TLS, so TLS1.2 needs to be used to access it.