### PR TITLE
Fixing Query Parameter issue

### DIFF
--- a/src/Vault/VaultClient.cs
+++ b/src/Vault/VaultClient.cs
@@ -119,8 +119,7 @@ namespace Vault
             if (parameters == null) return uriBuilder.Uri;
 
             var dict = parameters.AllKeys.ToDictionary(t => t, t => parameters[t]);
-            uriBuilder.Query = QueryHelpers.AddQueryString(string.Empty, dict);
-            return uriBuilder.Uri;
+            return new Uri(QueryHelpers.AddQueryString(uriBuilder.Uri.ToString(), dict));	
         }
     }
 


### PR DESCRIPTION
Using the existing method for URIs with query strings it yields:
http://google.com/test??list=true

with this change it yields:
http://google.com/test?list=true

This fixes the problem of the Secret.List command, as it won't return a proper list of keys but all the secrets with their values.
