### PR TITLE
Define Request From Local Cerificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Vault.NET Local Certificate
 
+Required NuGe Packages:
+
+- Microsoft.AspNet.WebApi.Client
+
 I have defined a new property "CertPah" that is populated before the definition of the httpcliet.
 
 In case it is empty, the behavior remains unchanged.

--- a/README.md
+++ b/README.md
@@ -1,98 +1,24 @@
-# Vault.NET [![Build status](https://ci.appveyor.com/api/projects/status/784hg5j70vcnumeb/branch/master?svg=true)](https://ci.appveyor.com/project/chatham/vault-net/branch/master)
+# Vault.NET Local Certificate
 
-* Vault API: v0.9.1
-* .NET Standard 1.3 (.NET: >= 4.6, .NET Core: >= 1.0.0)
-* .NET 4.5
-* Nuget: Vault [![NuGet](https://img.shields.io/nuget/v/Vault.svg)](https://www.nuget.org/packages/Vault/)
+I have defined a new property "CertPah" that is populated before the definition of the httpcliet.
 
-Vault.NET is an .NET API client for the interacting with [Vault](https://www.vaultproject.io/).  This is a port of the go api client and provides generic methods for interacting with the paths in Vault.  
+In case it is empty, the behavior remains unchanged.
 
-## Example
+If it is different from empty, then the certificate is taken locally and contributes to Vault API calls.
 
-```csharp
-using Vault;
-
-var vaultClient = new VaultClient();
-vaultClient.Token = "XXXXXX";
-```
-
-### Generic Secret
-
-```csharp
-var data = new Dictionary<string, string>
+```csharp   
+public static async Task<Dictionary<string, string>> VaultAsync(string secretPath)
 {
-    {"zip", "zap"}
-};
-await vaultClient.Secret.Write("secret/foo", data);
+    VaultOptions.Default.CertPath = new DirectoryInfo(
+        Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\..\" + "AppData\\cert.crt"))
+    ).ToString();
 
-var secret = await vaultClient.Secret.Read<Dictionary<string, string>>("secret/foo");
-Console.WriteLine(secret.Data["zip"]);
+    var vaultClient = new VaultClient();
+    vaultClient.Address = new System.Uri("https://vault.personal.domain.com:8200");
+    vaultClient.Token = "token";
 
-// zap
-```
+    var secret = await vaultClient.Secret.Read<Dictionary<string, string>>(secretPath);
 
-### PKI
-
-```csharp
-using Vault.Models.Secret.Pki;
-
-var testRole = new RolesRequest
-{
-    AllowAnyDomain = true,
-    EnforceHostnames = false,
-    MaxTtl = "1h"
-};
-await vaultClient.Secret.Write("pki/roles/test", testRole);
-
-var certRequest = new IssueRequest
-{
-    CommonName = "Test Cert"
-};
-var cert = await vaultClient.Secret.Write<IssueRequest, IssueResponse>("pki/issue/test", certRequest);
-Console.WriteLine(secret.Data.Certificate);
-
-// -----BEGIN CERTIFICATE-----
-// MII...
-```
-
-### Username/Password Authentication
-
-```csharp
-using Vault.Models.Auth.UserPass;
-
-await vaultClient.Sys.EnableAuth("userpass", "userpass", "Userpass Mount");
-
-var usersRequest = new UsersRequest
-{
-    Password = "password",
-    Policies = new List<string> { "default" },
-    Ttl = "1h",
-    MaxTtl = "2h"
-};
-await vaultClient.Auth.Write("userpass/users/username", usersRequest);
-
-var loginRequest = new LoginRequest
-{
-    Password = "password"
-};
-var loginResponse = await vaultClient.Auth.Write<LoginRequest, NoData>("userpass/login/username", loginRequest);
-
-// Set client token to authenticated token
-vaultClient.Token = loginResponse.Auth.ClientToken;
-
-// Proceed with authenticated requests
-```
-
-## Models
-
-Many request/response objects are provided in this package to support different backends.  This is in no way an exhaustive list of all the objects.  Since the models are the things that are going to most likely change between versions of vault, it may make sense to make your own to service your needs.  These may get split into a seperate Nuget package in the future.
-
-## Testing
-
-Since most of the operation of this library are just building requests and passing them to the vault API and the vault team provides an easy to use local development server, each test runs against its own vault server.  This means that tests require the vault binary available to spin up the vault server instance.  The test suite will first look for the environment variable `VAULT_BIN` and if not found will fall back to use the `vault` binary in the `$PATH`.
-
-Downloads for vault can be found [here](https://www.vaultproject.io/downloads.html).
-
-## Versioning
-
-This library will follow the version of vault that it was developed against.  Since most core operations of vault maintain backwards compatibility, this library can be used against many older and newer versions of vault.  If features are added or bugs are fixed, a new point release will be created (ex. 0.6.4 -> 0.6.4.1).  If there is some functionality that breaks on a newer version of vault, please submit a pull request.
+    return secret.Data;
+}    
+```    

--- a/README.md
+++ b/README.md
@@ -1,29 +1,87 @@
-# Vault.NET Local Certificate
+# Vault.NET [![Build status](https://ci.appveyor.com/api/projects/status/784hg5j70vcnumeb/branch/master?svg=true)](https://ci.appveyor.com/project/chatham/vault-net/branch/master)
 
-Required Packages/Assembly:
+* Vault API: v0.9.1
+* .NET Standard 1.3 (.NET: >= 4.6, .NET Core: >= 1.0.0)
+* .NET 4.5
+* Nuget: Vault [![NuGet](https://img.shields.io/nuget/v/Vault.svg)](https://www.nuget.org/packages/Vault/)
 
-- Microsoft.AspNet.WebApi.Client
-- System.Net.Http.Formatting.dll
+Vault.NET is an .NET API client for the interacting with [Vault](https://www.vaultproject.io/).  This is a port of the go api client and provides generic methods for interacting with the paths in Vault.  
 
-I have defined a new property "CertPah" that is populated before the definition of the httpcliet.
+## Example
 
-In case it is empty, the behavior remains unchanged.
+```csharp
+using Vault;
+var vaultClient = new VaultClient();
+vaultClient.Token = "XXXXXX";
+```
 
-If it is different from empty, then the certificate is taken locally and contributes to Vault API calls.
+### Generic Secret
 
-```csharp   
-public static async Task<Dictionary<string, string>> VaultAsync(string secretPath)
+```csharp
+var data = new Dictionary<string, string>
 {
-    VaultOptions.Default.CertPath = new DirectoryInfo(
-        Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\..\" + "AppData\\cert.crt"))
-    ).ToString();
+    {"zip", "zap"}
+};
+await vaultClient.Secret.Write("secret/foo", data);
+var secret = await vaultClient.Secret.Read<Dictionary<string, string>>("secret/foo");
+Console.WriteLine(secret.Data["zip"]);
+// zap
+```
 
-    var vaultClient = new VaultClient();
-    vaultClient.Address = new System.Uri("https://vault.personal.domain.com:8200");
-    vaultClient.Token = "token";
+### PKI
 
-    var secret = await vaultClient.Secret.Read<Dictionary<string, string>>(secretPath);
+```csharp
+using Vault.Models.Secret.Pki;
+var testRole = new RolesRequest
+{
+    AllowAnyDomain = true,
+    EnforceHostnames = false,
+    MaxTtl = "1h"
+};
+await vaultClient.Secret.Write("pki/roles/test", testRole);
+var certRequest = new IssueRequest
+{
+    CommonName = "Test Cert"
+};
+var cert = await vaultClient.Secret.Write<IssueRequest, IssueResponse>("pki/issue/test", certRequest);
+Console.WriteLine(secret.Data.Certificate);
+// -----BEGIN CERTIFICATE-----
+// MII...
+```
 
-    return secret.Data;
-}    
-```    
+### Username/Password Authentication
+
+```csharp
+using Vault.Models.Auth.UserPass;
+await vaultClient.Sys.EnableAuth("userpass", "userpass", "Userpass Mount");
+var usersRequest = new UsersRequest
+{
+    Password = "password",
+    Policies = new List<string> { "default" },
+    Ttl = "1h",
+    MaxTtl = "2h"
+};
+await vaultClient.Auth.Write("userpass/users/username", usersRequest);
+var loginRequest = new LoginRequest
+{
+    Password = "password"
+};
+var loginResponse = await vaultClient.Auth.Write<LoginRequest, NoData>("userpass/login/username", loginRequest);
+// Set client token to authenticated token
+vaultClient.Token = loginResponse.Auth.ClientToken;
+// Proceed with authenticated requests
+```
+
+## Models
+
+Many request/response objects are provided in this package to support different backends.  This is in no way an exhaustive list of all the objects.  Since the models are the things that are going to most likely change between versions of vault, it may make sense to make your own to service your needs.  These may get split into a seperate Nuget package in the future.
+
+## Testing
+
+Since most of the operation of this library are just building requests and passing them to the vault API and the vault team provides an easy to use local development server, each test runs against its own vault server.  This means that tests require the vault binary available to spin up the vault server instance.  The test suite will first look for the environment variable `VAULT_BIN` and if not found will fall back to use the `vault` binary in the `$PATH`.
+
+Downloads for vault can be found [here](https://www.vaultproject.io/downloads.html).
+
+## Versioning
+
+This library will follow the version of vault that it was developed against.  Since most core operations of vault maintain backwards compatibility, this library can be used against many older and newer versions of vault.  If features are added or bugs are fixed, a new point release will be created (ex. 0.6.4 -> 0.6.4.1).  If there is some functionality that breaks on a newer version of vault, please submit a pull request.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Vault.NET Local Certificate
 
-Required NuGe Packages:
+Required Packages/Assembly:
 
 - Microsoft.AspNet.WebApi.Client
+- System.Net.Http.Formatting.dll
 
 I have defined a new property "CertPah" that is populated before the definition of the httpcliet.
 

--- a/src/Vault/Vault.csproj
+++ b/src/Vault/Vault.csproj
@@ -28,13 +28,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Formatting" />    
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client">
-      <Version>5.2.4</Version>
-    </PackageReference>
-  </ItemGroup>  
 
 </Project>

--- a/src/Vault/Vault.csproj
+++ b/src/Vault/Vault.csproj
@@ -28,6 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />    
   </ItemGroup>
 
 </Project>

--- a/src/Vault/Vault.csproj
+++ b/src/Vault/Vault.csproj
@@ -29,5 +29,11 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client">
+      <Version>5.2.4</Version>
+    </PackageReference>
+  </ItemGroup>  
 
 </Project>

--- a/src/Vault/Vault.csproj
+++ b/src/Vault/Vault.csproj
@@ -28,6 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Formatting" />    
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -14,7 +14,7 @@ namespace Vault
 {
     public class VaultHttpClient : IVaultHttpClient
     {
-        public static HttpClient HttpClientinitialization()
+        private static HttpClient HttpClientInitialization()
         {
             HttpClient httpClient = new HttpClient();
             
@@ -56,7 +56,7 @@ namespace Vault
             return httpClient;
         }
 
-        private static readonly HttpClient HttpClient = HttpClientinitialization();
+        private static readonly HttpClient HttpClient = HttpClientInitialization();
 
         public VaultHttpClient()
         {

--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -16,7 +16,7 @@ namespace Vault
     {
         public static HttpClient HttpClientinitialization()
         {
-            HttpClient httpClient = null;
+            HttpClient httpClient = new HttpClient();
             
             #if NET45
                 if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))

--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -17,20 +17,21 @@ namespace Vault
         public static HttpClient HttpClientinitialization()
         {
             HttpClient httpClient = null;
-            var handler = new HttpClientHandler();
-
+            
             #if NET45
                 if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))
                 {
-                    X509Certificate cert = new X509Certificate();
-                    cert.Import(Vault.VaultOptions.Default.CertPath);
-                    httpClient = new HttpClient(handler);
+                    WebRequestHandler requestHandler = new WebRequestHandler();
+                    requestHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                    requestHandler.ClientCertificates.Add(new X509Certificate2(Vault.VaultOptions.Default.CertPath));
+                    httpClient = new HttpClient(requestHandler);
                 }
                 else
                     httpClient = new HttpClient();
             #else
             if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))
             {
+                var handler = new HttpClientHandler();            
                 handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
                 {
                     const SslPolicyErrors unforgivableErrors =

--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -29,29 +29,29 @@ namespace Vault
                 else
                     httpClient = new HttpClient();
             #else
-            if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))
-            {
-                var handler = new HttpClientHandler();            
-                handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
+                if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))
                 {
-                    const SslPolicyErrors unforgivableErrors =
-                        SslPolicyErrors.RemoteCertificateNotAvailable |
-                        SslPolicyErrors.RemoteCertificateNameMismatch;
-
-                    if ((errors & unforgivableErrors) != 0)
+                    var handler = new HttpClientHandler();            
+                    handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
                     {
-                        return false;
-                    }
+                        const SslPolicyErrors unforgivableErrors =
+                            SslPolicyErrors.RemoteCertificateNotAvailable |
+                            SslPolicyErrors.RemoteCertificateNameMismatch;
 
-                    X509Certificate2 remoteRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
-                    return new X509Certificate2(Vault.VaultOptions.Default.CertPath).RawData.SequenceEqual(remoteRoot.RawData);
-                };
-                httpClient = new HttpClient(handler);
-            }
-            else
-            {
-                httpClient = new HttpClient();
-            }
+                        if ((errors & unforgivableErrors) != 0)
+                        {
+                            return false;
+                        }
+
+                        X509Certificate2 remoteRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                        return new X509Certificate2(Vault.VaultOptions.Default.CertPath).RawData.SequenceEqual(remoteRoot.RawData);
+                    };
+                    httpClient = new HttpClient(handler);
+                }
+                else
+                {
+                    httpClient = new HttpClient();
+                }
             #endif
             return httpClient;
         }

--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -16,7 +16,7 @@ namespace Vault
     {
         private static HttpClient HttpClientInitialization()
         {
-            HttpClient httpClient = new HttpClient();
+            HttpClient httpClient = null;
             
             #if NET45
                 if (!string.IsNullOrEmpty(Vault.VaultOptions.Default.CertPath))

--- a/src/Vault/VaultOptions.cs
+++ b/src/Vault/VaultOptions.cs
@@ -8,6 +8,7 @@ namespace Vault
 
         public string Address { get; set; } = "https://localhost:8200";
         public string Token { get; set; }
+        public string CertPath { get; set; }        
 
         VaultOptions IOptions<VaultOptions>.Value => this;
     }

--- a/test/Vault.Tests/Vault.Tests.csproj
+++ b/test/Vault.Tests/Vault.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4" />    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/Vault.Tests/Vault.Tests.csproj
+++ b/test/Vault.Tests/Vault.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4" />    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
In my use case I need to validate a certificate that resides in the local machine in order to ensure the correct communication with Vault placed on a host machine reachable on https.

To do this I introduced a new property in the VaultOptions that will be started with the path of the certified.

Within the VaultHttpClient class I inserted a method that initializes HttpClient with the result of the HttpClientinitialization () method which, in case the property is populated, passes the hundler parameter to HttpClient, thus specifying the certificate to be used with X509Certificate2. Otherwise the behavior of the plugin will remain unchanged.

I report the scenario with which the test was conducted:

public static async Task<Dictionary<string, string>> VaultAsync(string secretPath)
{
    VaultOptions.Default.CertPath = new DirectoryInfo(
        Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\..\" + "AppData\\cert.crt"))
    ).ToString();

    var vaultClient = new VaultClient();
    vaultClient.Address = new System.Uri("https://vault.personal.domain.com:8200");
    vaultClient.Token = "token";

    var secret = await vaultClient.Secret.Read<Dictionary<string, string>>(secretPath);

    return secret.Data;
}