### PR TITLE
Exposing HttpClient.Timeout in VaultHttpClient

### DIFF
--- a/src/Vault/VaultHttpClient.cs
+++ b/src/Vault/VaultHttpClient.cs
@@ -12,6 +12,11 @@ namespace Vault
     public class VaultHttpClient : IVaultHttpClient
     {
         private static readonly HttpClient HttpClient = new HttpClient();
+        public static TimeSpan Timeout
+        {
+            get { return HttpClient.Timeout; }
+            set { HttpClient.Timeout = value; }
+        }
 
         public VaultHttpClient()
         {


### PR DESCRIPTION
 * Timeout getter/setter in VaultHttpClient to modify static HttpClient Timeout

The default timeout for an HttpClient is 100 seconds, which is really long for our use case. We are trying to solve a timeout issue when calling the Transit Encryption engine (which should be very lightweight, so it is likely a network issue on our part), so would like to do a back-off and single retry in order to help mitigate our problem. Waiting up to 200 seconds is simply too long for us in this case though, so we would like some way to modify the default timeout on the HttpClient that the VaultHttpClient uses. We are currently re-implementing the entire interface in our project in order to work around this.

It did feel a bit odd to add the property to the VaultClient that ends up calling through to the static class member, so if there is another way you'd like that done, I'd be more than willing to change it. I was thinking about doing it via the VaultOptions, but that would have required a bit more work.